### PR TITLE
fix package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdn-classlist.js",
-  "version": "1.0.0",
+  "version": "1.1.20150312",
   "description": "Cross-browser JavaScript shim that fully implements element.classList (referenced on MDN)",
   "main": "classList.js",
   "directories": {
@@ -20,7 +20,7 @@
     "cross-browser"
   ],
   "author": "me@eligrey.com",
-  "license": "Unlicense",
+  "license": "Public Domain",
   "bugs": {
     "url": "https://github.com/eligrey/classList.js/issues"
   },


### PR DESCRIPTION
- update to the correct version `1.1.20150312`
- change the license to `Public Domain`
- see https://github.com/eligrey/classList.js/pull/46#issuecomment-189783812
